### PR TITLE
Change thread backend

### DIFF
--- a/src/libstd/sys/switch/thread.rs
+++ b/src/libstd/sys/switch/thread.rs
@@ -6,129 +6,94 @@ use crate::ptr;
 use crate::sys::os;
 use crate::time::Duration;
 
-use nnsdk::{os::SleepThread, TimeSpan};
+use nnsdk::TimeSpan;
+
+pub const STACK_GRANULARITY: usize = 0x1000;
 
 #[cfg(not(target_os = "l4re"))]
 pub const DEFAULT_MIN_STACK_SIZE: usize = 2 * 1024 * 1024;
 #[cfg(target_os = "l4re")]
 pub const DEFAULT_MIN_STACK_SIZE: usize = 1024 * 1024;
-
 pub struct Thread {
-    id: libc::pthread_t,
+    native: *mut nnsdk::os::ThreadType
 }
 
-// Some platforms may have pthread_t as a pointer in which case we still want
-// a thread to be Send/Sync
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
 
-unsafe fn pthread_attr_setstacksize(
-    attr: *mut libc::pthread_attr_t,
-    stack_size: libc::size_t,
-) -> libc::c_int {
-    libc::pthread_attr_setstacksize(attr, stack_size)
-}
-
 impl Thread {
-    // unsafe: see thread::Builder::spawn_unchecked for safety requirements
     pub unsafe fn new(stack: usize, p: Box<dyn FnOnce()>) -> io::Result<Thread> {
         let p = Box::into_raw(box p);
-        let mut native: libc::pthread_t = mem::zeroed();
-        let mut attr: libc::pthread_attr_t = mem::zeroed();
-        assert_eq!(libc::pthread_attr_init(&mut attr), 0);
+        
+        let _native: nnsdk::os::ThreadType = mem::zeroed();
+        let mut native: *mut nnsdk::os::ThreadType = Box::into_raw(Box::new(_native));
+        let mut stack_size = cmp::max(stack, STACK_GRANULARITY);
+        if stack_size % STACK_GRANULARITY != 0 {
+            // Pretty sure that alignment is 0x1000 and that is the minimum that you can have soooo..
+            stack_size = ((STACK_GRANULARITY - (stack_size % STACK_GRANULARITY)) % STACK_GRANULARITY) + stack_size;
+        }
 
-        let stack_size = cmp::max(stack, min_stack_size(&attr));
+        println!("{}", stack_size);
 
-        match pthread_attr_setstacksize(&mut attr, stack_size) {
-            0 => {}
-            n => {
-                assert_eq!(n, libc::EINVAL);
-                // EINVAL means |stack_size| is either too small or not a
-                // multiple of the system page size.  Because it's definitely
-                // >= PTHREAD_STACK_MIN, it must be an alignment issue.
-                // Round up to the nearest page and try again.
-                let page_size = os::page_size();
-                let stack_size =
-                    (stack_size + page_size - 1) & (-(page_size as isize - 1) as usize - 1);
-                assert_eq!(libc::pthread_attr_setstacksize(&mut attr, stack_size), 0);
-            }
-        };
-
-        let ret = libc::pthread_create(&mut native, &attr, thread_start, p as *mut _);
-        // Note: if the thread creation fails and this assert fails, then p will
-        // be leaked. However, an alternative design could cause double-free
-        // which is clearly worse.
-        assert_eq!(libc::pthread_attr_destroy(&mut attr), 0);
-
+        let mut stack_mem: *mut libc::c_void = 0 as *mut libc::c_void;
+        libc::posix_memalign(&mut stack_mem, STACK_GRANULARITY, stack_size);
+        assert!(stack_mem != 0 as *mut libc::c_void);
+        
+        let ret = nnsdk::os::CreateThread1(native, thread_start, p as *mut _, stack_mem, stack_size as u64, 31i32);
         return if ret != 0 {
-            // The thread failed to start and as a result p was not consumed. Therefore, it is
-            // safe to reconstruct the box so that it gets deallocated.
             drop(Box::from_raw(p));
-            Err(io::Error::from_raw_os_error(ret))
+            drop(Box::from_raw(native));
+            libc::free(stack_mem);
+            Err(io::Error::last_os_error())
         } else {
-            Ok(Thread { id: native })
+            nnsdk::os::StartThread(native);
+            Ok(Thread { native: native })
         };
 
-        extern "C" fn thread_start(main: *mut libc::c_void) -> *mut libc::c_void {
+        extern "C" fn thread_start(main: *mut libc::c_void) {
             unsafe {
-                // Next, set up our stack overflow handler which may get triggered if we run
-                // out of stack.
-                //let _handler = stack_overflow::Handler::new();
-                // Finally, let's run some code.
                 Box::from_raw(main as *mut Box<dyn FnOnce()>)();
             }
-            ptr::null_mut()
         }
+
     }
 
     pub fn yield_now() {
-        let ret = unsafe { libc::sched_yield() };
-        debug_assert_eq!(ret, 0);
+        unsafe {
+            nnsdk::os::YieldThread();
+        }
     }
 
     pub fn set_name(name: &CStr) {
         use crate::ffi::CString;
         let cname = CString::new(&b"%s"[..]).unwrap();
         unsafe {
-            libc::pthread_setname_np(
-                libc::pthread_self(),
-                cname.as_ptr(),
-                name.as_ptr() as *mut libc::c_void,
-            );
+            nnsdk::os::SetThreadName(nnsdk::os::GetCurrentThread(), cname.as_ptr() as *const u8);   
         }
     }
 
     pub fn sleep(dur: Duration) {
         let time_span = TimeSpan::nano(dur.as_nanos() as u64);
-
         unsafe {
-            SleepThread(time_span);
+            nnsdk::os::SleepThread(time_span);
         }
     }
 
-    pub fn join(self) {
+    pub fn join(mut self) {
         unsafe {
-            let ret = libc::pthread_join(self.id, ptr::null_mut());
+            nnsdk::os::WaitThread(self.native);
+            nnsdk::os::DestroyThread(self.native);
             mem::forget(self);
-            assert!(ret == 0, "failed to join thread: {}", io::Error::from_raw_os_error(ret));
         }
     }
-
-    // pub fn id(&self) -> libc::pthread_t {
-    //     self.id
-    // }
-
-    // pub fn into_id(self) -> libc::pthread_t {
-    //     let id = self.id;
-    //     mem::forget(self);
-    //     id
-    // }
 }
 
 impl Drop for Thread {
     fn drop(&mut self) {
-        let ret = unsafe { libc::pthread_detach(self.id) };
-        debug_assert_eq!(ret, 0);
+        unsafe {
+            // nnsdk::os::DestroyThread(&mut self.native);
+            // change this if needed, but i feel like threads should exist beyond when they are dropped.
+        }
     }
 }
 
@@ -142,8 +107,4 @@ pub mod guard {
     pub unsafe fn init() -> Option<Guard> {
         None
     }
-}
-
-fn min_stack_size(_: *const libc::pthread_attr_t) -> usize {
-    0x1000 // just a guess
 }

--- a/src/libstd/sys/switch/thread.rs
+++ b/src/libstd/sys/switch/thread.rs
@@ -32,9 +32,7 @@ impl Thread {
             // Pretty sure that alignment is 0x1000 and that is the minimum that you can have soooo..
             stack_size = ((STACK_GRANULARITY - (stack_size % STACK_GRANULARITY)) % STACK_GRANULARITY) + stack_size;
         }
-
-        println!("{}", stack_size);
-
+        
         let mut stack_mem: *mut libc::c_void = 0 as *mut libc::c_void;
         libc::posix_memalign(&mut stack_mem, STACK_GRANULARITY, stack_size);
         assert!(stack_mem != 0 as *mut libc::c_void);
@@ -83,6 +81,7 @@ impl Thread {
         unsafe {
             nnsdk::os::WaitThread(self.native);
             nnsdk::os::DestroyThread(self.native);
+            drop(Box::from_raw(self.native));
             mem::forget(self);
         }
     }


### PR DESCRIPTION
use nnsdk stuff for threads. idk if it had any performance benefits but it uses nnsdk stuff and makes me feel useful

known issues:
1. inability to spawn threads from within a thread. this might be my use case specifically or a limitation of nnsdk. feel free to experiment